### PR TITLE
Exit with error when it's not possible to locate Chrome's files

### DIFF
--- a/src/eos-google-chrome-app
+++ b/src/eos-google-chrome-app
@@ -5,6 +5,7 @@
 # Copyright (C) 2016 Endless Mobile, Inc.
 # Authors:
 #  Mario Sanchez Prada <mario@endlessm.com>
+#  Joaquim Rocha <jrocha@endlessm.com>
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -149,6 +150,8 @@ class GoogleChromeFlatpakLauncher:
             runtime_path = os.path.join(runtime_path, 'files')
             if not os.path.exists(runtime_path):
                 exit_with_error("Could not find Chrome's binaries in external runtime directory")
+        else:
+            exit_with_error("Could not find Chrome's external runtime")
 
         return runtime_path
 


### PR DESCRIPTION
If neither the /app/extra directory nor the Chrome's runtime is
found (this one only for our custom implementation of external apps),
we need to exit with an error, or the app_info['chrome_path'] value
will be None, which will crash the launcher later on.

This should not ever happen unless there was some kind of problem
during the installation of Chrome, using the new external-apps logic,
or that the app was previously installed with our custom system for
external-apps but, for any reason, the associated runtime was not
installed or removed afterwards somehow (com.google.Chrome.external).

Either way, there's not much the user can do in this case other
than uninstalling and re-installing Chrome, which will force using
downloading everything and putting it in place again.

For this reason we need to exit early and log an error, so that at
least we have a clue in the journal of what's going on.

https://phabricator.endlessm.com/T15142