### PR TITLE
add back missing system-desktop-file metadata

### DIFF
--- a/com.google.Chrome.appdata.xml
+++ b/com.google.Chrome.appdata.xml
@@ -60,6 +60,7 @@
 
 
     <metadata>
+<value key="EndlessOS::system-desktop-file">google-chrome.desktop</value>
 <value key="GnomeSoftware::popular-background">https://d3lapyynmdp1i9.cloudfront.net/thumbnails/com.google.Chrome/com.google.chrome-thumb.jpg</value>
     </metadata>
 


### PR DESCRIPTION
Accidentally dropped this from the appdata file, causing a regression of
T14103.

https://phabricator.endlessm.com/T21837