### PR TITLE
Specify eos3 branch in manifest for flatpak-builder

### DIFF
--- a/com.google.Chrome.json
+++ b/com.google.Chrome.json
@@ -1,5 +1,6 @@
 {
     "app-id": "com.google.Chrome",
+    "branch": "eos3",
     "runtime": "org.freedesktop.Platform",
     "runtime-version": "1.6",
     "sdk": "org.freedesktop.Sdk",


### PR DESCRIPTION
Tell flatpak-builder what branch to use so that it exports to eos3
instead of the default master. I'm pretty sure we'll only ever publish
to an eos3 branch, but if this needs to be dynamic, we can move to a
json.in file and use `@BRANCH@`, which is substituted by our scripts.

https://phabricator.endlessm.com/T22309