### PR TITLE
T23841: Bundle a copy of the Endless patched Adwaita theme

### DIFF
--- a/com.google.Chrome.json
+++ b/com.google.Chrome.json
@@ -59,44 +59,6 @@
             ]
         },
         {
-            "name": "dbus-glib",
-            "cleanup": [ "/bin", "/libexec", "/etc/bash_completion.d" ],
-            "config-opts": [
-                "--disable-static",
-                "--disable-gtk-doc"
-            ],
-            "sources": [
-                {
-                    "type": "archive",
-                    "url": "https://dbus.freedesktop.org/releases/dbus-glib/dbus-glib-0.108.tar.gz",
-                    "sha256": "9f340c7e2352e9cdf113893ca77ca9075d9f8d5e81476bf2bf361099383c602c"
-                }
-            ]
-        },
-        {
-            "name": "gconf",
-            "cleanup": [
-              "/bin",
-              "/libexec",
-              "/share/sgml",
-              "/etc/xdg/autostart",
-              "/share/dbus-1"
-            ],
-            "config-opts": [
-                "--disable-static",
-                "--disable-gtk-doc",
-                "--disable-orbit",
-                "--disable-introspection"
-            ],
-            "sources": [
-                {
-                    "type": "archive",
-                    "url": "https://download.gnome.org/sources/GConf/3.2/GConf-3.2.6.tar.xz",
-                    "sha256": "1912b91803ab09a5eed34d364bf09fe3a2a9c96751fde03a4e0cfa51a04d784c"
-                }
-            ]
-        },
-        {
             "name": "chrome",
             "buildsystem": "simple",
             "sources": [
@@ -130,6 +92,7 @@
             "build-commands": [
                 "install apply_extra /app/bin/apply_extra",
                 "install /usr/bin/ar /app/bin/ar",
+                "install -d /app/lib",
                 "install -t /app/lib /usr/lib/libbfd-*.so"
             ]
         }

--- a/com.google.Chrome.json
+++ b/com.google.Chrome.json
@@ -66,9 +66,9 @@
                     "type": "extra-data",
                     "filename": "chrome.deb",
                     "only-arches": [ "x86_64" ],
-                    "url": "https://dl.google.com/linux/chrome/deb/pool/main/g/google-chrome-stable/google-chrome-stable_69.0.3497.81-1_amd64.deb",
-                    "sha256": "c7abef9eb7299a8e442c9affa0f5dd0f7b25739fb377b9cfc0dd7a59d0827ab8",
-                    "size": 54688734,
+                    "url": "https://dl.google.com/linux/chrome/deb/pool/main/g/google-chrome-stable/google-chrome-stable_69.0.3497.100-1_amd64.deb",
+                    "sha256": "180cbc8dc9f36bc3022556c046c5ac723607beaf6d1ec395b433c556e199a670",
+                    "size": 54675966,
                     "x-checker-data": {
                         "type": "debian-repo",
                         "package-name": "google-chrome-stable",

--- a/com.google.Chrome.json
+++ b/com.google.Chrome.json
@@ -95,6 +95,22 @@
                 "install -d /app/lib",
                 "install -t /app/lib /usr/lib/libbfd-*.so"
             ]
+        },
+        {
+            "name": "gtk-theme",
+            "buildsystem": "simple",
+            "sources": [
+                {
+                    "type": "git",
+                    "url": "https://github.com/endlessm/gtk/",
+                    "branch": "eos-google-chrome-app"
+                }
+            ],
+            "build-commands": [
+                "install -d /app/share/themes/Endless-Chrome/gtk-3.0/assets",
+                "install -t /app/share/themes/Endless-Chrome/gtk-3.0/assets gtk/theme/Adwaita/assets/*.{png,svg}",
+                "install -t /app/share/themes/Endless-Chrome/gtk-3.0 gtk/theme/Adwaita/*.css"
+            ]
         }
     ]
 }

--- a/eos-google-chrome-app
+++ b/eos-google-chrome-app
@@ -171,9 +171,6 @@ class GoogleChromeFlatpakLauncher:
         if not os.path.exists(app_lib_path):
             exit_with_error("Could not find bundled libraries for Chrome")
 
-        if app_path and not app_lib_path:
-            exit_with_error("Chrome's installation directory found, but not bundled libraries")
-
         chrome_path = os.path.join(app_path, 'files', 'extra')
         # We check for legacy runtimes to maintain backward-compatibility for users without
         # support for native external apps (Flatpak <0.6.13)

--- a/eos-google-chrome-app
+++ b/eos-google-chrome-app
@@ -103,8 +103,15 @@ class GoogleChromeFlatpakLauncher:
             except OSError as e:
                 exit_with_error("Could not run sandbox process: {}".format(repr(e)))
 
-            # Bundled libraries need to be taken also into account
+            # Bundled data and libraries need to be taken also into account
+            data_dirs = app_info['app_data_path']
+            if 'XDG_DATA_DIRS' in os.environ:
+                data_dirs = ':'.join((data_dirs, os.environ['XDG_DATA_DIRS']))
+            os.environ['XDG_DATA_DIRS'] = data_dirs
             os.environ['LD_LIBRARY_PATH'] = app_info['app_lib_path']
+
+            # Override GTK theme to the bundled Adwaita variant
+            os.environ['GTK_THEME'] = 'Endless-Chrome'
 
             chrome_bin_path = os.path.join(app_info['chrome_path'], 'opt', 'google', 'chrome',
                                            'google-chrome')
@@ -167,6 +174,10 @@ class GoogleChromeFlatpakLauncher:
         if not app_path or not os.path.exists(app_path):
             exit_with_error("Could not find Chrome's application directory")
 
+        app_data_path = os.path.join(app_path, 'files/share')
+        if not os.path.exists(app_data_path):
+            exit_with_error("Could not find bundled data for Chrome")
+
         app_lib_path = os.path.join(app_path, 'files/lib')
         if not os.path.exists(app_lib_path):
             exit_with_error("Could not find bundled libraries for Chrome")
@@ -179,7 +190,11 @@ class GoogleChromeFlatpakLauncher:
                             "back to the legacy runtime...")
             chrome_path = self._get_legacy_chrome_runtime_path(app_path)
 
-        app_info = {'app_lib_path': app_lib_path, 'chrome_path': chrome_path}
+        app_info = {
+            'app_data_path': app_data_path,
+            'app_lib_path': app_lib_path,
+            'chrome_path': chrome_path
+        }
         logging.info("Found information for Chrome: %s", repr(app_info))
         return app_info
 


### PR DESCRIPTION
Fetch our Adwaita theme from a new eos-google-chrome-app branch in our Gtk+
repo, and ship a copy of the CSS and assets as a local Endless-Chrome theme.
Add it to the XDG_DATA_DIRS and set GTK_THEME so that it is used when launching
Chrome.

https://phabricator.endlessm.com/T23841
