### PR TITLE
Drop gtk theme changes

### DIFF
--- a/com.google.Chrome.json
+++ b/com.google.Chrome.json
@@ -94,23 +94,6 @@
                 "install -d /app/lib",
                 "install -t /app/lib /usr/lib/x86_64-linux-gnu/libbfd-*.so"
             ]
-        },
-        {
-            "name": "gtk-theme",
-            "buildsystem": "simple",
-            "sources": [
-                {
-                    "type": "git",
-                    "url": "https://github.com/endlessm/gtk/",
-                    "branch": "eos-google-chrome-app"
-                }
-            ],
-            "build-commands": [
-                "install -d /app/share/themes/Endless-Chrome/gtk-3.0/assets",
-                "install -t /app/share/themes/Endless-Chrome/gtk-3.0/assets gtk/theme/Adwaita/assets/*.{png,svg}",
-                "install gtk/theme/Adwaita/gtk-contained.css /app/share/themes/Endless-Chrome/gtk-3.0/gtk.css",
-                "install gtk/theme/Adwaita/gtk-contained-dark.css /app/share/themes/Endless-Chrome/gtk-3.0/gtk-dark.css"
-            ]
         }
     ]
 }


### PR DESCRIPTION
This is in line with the changes introduced on 3.8.2-beta1, where we are now defaulting to light title bars.

Before:
![chrome-before](https://user-images.githubusercontent.com/5741111/82699389-f1febe80-9c42-11ea-8628-aff6f5c274c4.png)

After:
![chrome-after](https://user-images.githubusercontent.com/5741111/82699397-f4611880-9c42-11ea-88de-49a83c972038.png)

For comparison here is chromium on 3.8.2-beta1:
![chromium-3 8 2-beta1](https://user-images.githubusercontent.com/5741111/82699421-fe831700-9c42-11ea-8bf4-604acc5e99bd.png)

https://phabricator.endlessm.com/T29566