### PR TITLE
Fix support for creating desktop shortcuts

### DIFF
--- a/apply_extra.sh
+++ b/apply_extra.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/bash
+
+ar x chrome.deb
+rm -f chrome.deb
+tar xf data.tar.xz
+rm -f control.tar.?z data.tar.?z debian-binary
+
+mv opt/google/chrome/chrome opt/google/chrome/chrome-real
+cp /app/scripts/chrome opt/google/chrome/chrome

--- a/chrome.sh
+++ b/chrome.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+# Let the wrapped binary know that it has been run through the wrapper.
+#
+# This env variable will (only) be used by Chrome to determine the
+# executable path when creating desktop shortcuts so let's set it to
+# our system wrapper as the default is set to the google-chrome wrapper
+# absolute path which is specific to the flatpak version.
+export CHROME_WRAPPER="/usr/bin/eos-google-chrome"
+
+HERE="`dirname ${BASH_SOURCE[0]}`"
+
+exec "$HERE/chrome-real" "$@"

--- a/com.google.Chrome.appdata.xml
+++ b/com.google.Chrome.appdata.xml
@@ -70,6 +70,7 @@
   <url type="bugtracker">https://support.google.com/chrome/?p=feedback</url>
   <url type="help">https://support.google.com/chrome</url>
   <releases>
+    <release version="85.0.4183.102-2" date="2020-09-10"/>
     <release version="85.0.4183.102-1" date="2020-09-04"/>
     <release version="85.0.4183.83-1" date="2020-08-23"/>
     <release version="84.0.4147.135-1" date="2020-08-18"/>

--- a/com.google.Chrome.json
+++ b/com.google.Chrome.json
@@ -77,19 +77,17 @@
                     }
                 },
                 {
-                    "type": "script",
-                    "dest-filename": "apply_extra",
-                    "commands": [
-                        "ar x chrome.deb",
-                        "rm -f chrome.deb",
-                        "tar xf data.tar.xz",
-                        "rm -f control.tar.gz data.tar.xz debian-binary",
-                        "chmod a+xr ."
-                    ]
+                    "type": "file",
+                    "path": "apply_extra.sh"
+                },
+                {
+                    "type": "file",
+                    "path": "chrome.sh"
                 }
             ],
             "build-commands": [
-                "install apply_extra /app/bin/apply_extra",
+                "install -Dm 755 apply_extra.sh /app/bin/apply_extra",
+                "install -Dm 755 chrome.sh /app/scripts/chrome",
                 "install /usr/bin/ar /app/bin/ar",
                 "install -d /app/lib",
                 "install -t /app/lib /usr/lib/x86_64-linux-gnu/libbfd-*.so"


### PR DESCRIPTION
When creating desktop shortcuts chrome uses the value of the CHROME_WRAPPER env variable to build the .desktop file Exec line. 
The problem is that the default wrapper script shipped inside the google-chrome extra-data package sets this variable to the absolute path of the wrapper script itself which is tied to a specific version of this flatpak and will change on new updates and break existing shortcuts.

Let's rename/replace the original binary with another wrapper that sets CHROME_WRAPPER to our system launcher before invoking the real chrome binary.

https://phabricator.endlessm.com/T21357