### PR TITLE
Check for updates using GitHub Actions

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -1,0 +1,26 @@
+name: Check for updates
+
+on:
+  schedule:
+    - cron: '52 3/6 * * *'
+  workflow_dispatch:
+
+jobs:
+  check:
+    timeout-minutes: 5
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: docker://ghcr.io/flathub/flatpak-external-data-checker:latest
+        env:
+          GIT_AUTHOR_NAME: Endless External Data Checker
+          GIT_COMMITTER_NAME: Endless External Data Checker
+          GIT_AUTHOR_EMAIL: os@endlessos.org
+          GIT_COMMITTER_EMAIL: os@endlessos.org
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          # --never-fork is needed because the repository permissions
+          # reported by the GitHub API claim that the user cannot push to the
+          # repo, whereas in fact they can.
+          args: |
+            --verbose --update --never-fork com.google.Chrome.json


### PR DESCRIPTION
Previously, our Jenkins ran a Jenkinsfile in
https://github.com/endlessm/flatpak-external-data-checker which used a
wrapper script which checked a bunch of repos.

Today, the checker has moved to Flathub and only one Endless-specific
app remains to check: com.google.Chrome.

Run that same checker using GitHub Actions, removing the need to
maintain the Endless-specific Jenkinsfile and wrapper script in f-e-d-c
and making the whole thing a bit clearer. The workflow runs on a similar
schedule (every 6 hours) and can be manually triggered.
    
https://phabricator.endlessm.com/T32493
