### PR TITLE
eos-google-chrome-app: Only look in system installations for app

### DIFF
--- a/eos-google-chrome-app
+++ b/eos-google-chrome-app
@@ -50,7 +50,7 @@ def exit_with_error(message):
 
 
 def find_flatpak_ref(ref_id, kind=Flatpak.RefKind.APP, branch=None, arch=None):
-    installations = [Flatpak.Installation.new_user()] + Flatpak.get_system_installations()
+    installations = Flatpak.get_system_installations()
     ref_found = None
 
     for installation in installations:


### PR DESCRIPTION
The installer in eos-browser-tools installs to the system repo,
unconditionally, and `git log -S new_user` says it’s never considered
the user repo.

To avoid the possible situation where Chrome is available on flathub,
the user installs that to their user repo, has eos-google-chrome-app
installed to their system repo, and then runs the eos-google-chrome-app
script and it finds and starts the flathub Chrome rather than the
Endless Chrome, explicitly only consider the system repos in this
script.

Signed-off-by: Philip Withnall <pwithnall@endlessos.org>

https://phabricator.endlessm.com/T32409