### PR TITLE
Update runtime to org.freedesktop.Platform//21.08

### DIFF
--- a/com.google.Chrome.json
+++ b/com.google.Chrome.json
@@ -1,7 +1,7 @@
 {
     "app-id": "com.google.Chrome",
     "runtime": "org.freedesktop.Platform",
-    "runtime-version": "20.08",
+    "runtime-version": "21.08",
     "sdk": "org.freedesktop.Sdk",
     "command": "/app/bin/eos-google-chrome-app",
     "cleanup": [


### PR DESCRIPTION
This app doesn't actually use its runtime (except when deploying
extra-data) since it is run on the host system. However, we want it to
use a runtime that is included in all Endless OS images and is likely to
be widely installed.

Now that LibreOffice (which is pre-installed on all systems) uses the
21.08 version of the platform, this app can/should use it too.
