### PR TITLE
Remove duplicate and out-of-order release

### DIFF
--- a/com.google.Chrome.appdata.xml
+++ b/com.google.Chrome.appdata.xml
@@ -78,7 +78,6 @@
     <release version="117.0.5938.132-1" date="2023-09-27"/>
     <release version="117.0.5938.92-1" date="2023-09-20"/>
     <release version="117.0.5938.88-1" date="2023-09-15"/>
-    <release version="116.0.5845.187-1" date="2023-09-09"/>
     <release version="117.0.5938.62-1" date="2023-09-09"/>
     <release version="116.0.5845.187-1" date="2023-09-09"/>
     <release version="116.0.5845.179-1" date="2023-09-04"/>


### PR DESCRIPTION
This was introduced in commit 99e072992b5cbcb2c3135974fee5bb60ca6f121e
and causes the following two fatal errors from appstream-compose:

    com.google.Chrome.desktop:         AppData problem: tag-invalid : <release> version was duplicated
    com.google.Chrome.desktop:         AppData problem: tag-invalid : <release> versions are not in order [116.0.5845.187-1 before 117.0.5938.62-1]

You might reasonably argue that fedc should not generate such invalid
metainfo.

https://phabricator.endlessm.com/T34993
