### PR TITLE
Add libsframe.so to app (used by ar)

### DIFF
--- a/com.google.Chrome.json
+++ b/com.google.Chrome.json
@@ -90,6 +90,7 @@
                 "install -Dm 755 chrome.sh /app/scripts/chrome",
                 "install /usr/bin/ar /app/bin/ar",
                 "install -d /app/lib",
+                "install -t /app/lib /usr/lib/x86_64-linux-gnu/libsframe.so.1",
                 "install -t /app/lib /usr/lib/x86_64-linux-gnu/libbfd-*.so"
             ]
         }


### PR DESCRIPTION
At install time, `ar` (from binutils) is used to unpack Google's .deb. `ar` (from binutils) is part of org.freedesktop.Sdk but not .Platform. So at build time we copy `ar` to the app, as well as `libbfd` which it links to.

Compared to freedesktop-sdk 21.08, in 23.08 `ar` now links to `libsframe.so.1`, which is not part of the .Platform runtime, so installation fails as follows:

    ar: error while loading shared libraries: libsframe.so.1: cannot open shared object file: No such file or directory
    tar: data.tar.xz: Cannot open: No such file or directory
    tar: Error is not recoverable: exiting now
    mv: cannot stat 'opt/google/chrome/chrome': No such file or directory
    cp: cannot create regular file 'opt/google/chrome/chrome': No such file or directory

I evidently did not test the change in
https://github.com/endlessm/eos-google-chrome-app/pull/212 enough (at all?), and it is not caught in CI because our Jenkins jobs only build the apps, not install them, and this is an install-time problem. It follows that Chrome has been un-installable on Endless OS since March 27th.

Thanks to Bernhard Treutwein, James Martinez and pSy_ZeRo for reporting this issue.

Fixes: 2babe8def33448e8d18063cbf5819262c9653f0a

https://phabricator.endlessm.com/T35314