### PR TITLE
Fix libsframe version used by ar 2.45

### DIFF
--- a/com.google.Chrome.json
+++ b/com.google.Chrome.json
@@ -90,7 +90,7 @@
                 "install -Dm 755 chrome.sh /app/scripts/chrome",
                 "install /usr/bin/ar /app/bin/ar",
                 "install -d /app/lib",
-                "install -t /app/lib /usr/lib/x86_64-linux-gnu/libsframe.so.1",
+                "install -t /app/lib /usr/lib/x86_64-linux-gnu/libsframe.so.2",
                 "install -t /app/lib /usr/lib/x86_64-linux-gnu/libbfd-*.so"
             ]
         }


### PR DESCRIPTION
The Freedesktop SDK 23.08.33[1] release updated binutils to 2.45, which bumped the libsframe SONAME to 2.

1. https://gitlab.com/freedesktop-sdk/freedesktop-sdk/-/tags/freedesktop-sdk-23.08.33

https://phabricator.endlessm.com/T35870